### PR TITLE
Feat/memo page

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -58,6 +58,7 @@
 	</array>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>음성 녹음을 위해 마이크 권한이 필요합니다.</string>
+	<key>ITSAppUsesNonExemptEncryption</key> <No>
 	<key>NSFileProviderDomainUsageDescription</key>
     <string>앱이 로컬 데이터베이스에 접근하여 데이터를 저장하고 읽기 위해 권한이 필요합니다.</string>
     <key>NSDocumentsFolderUsageDescription</key>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -58,7 +58,7 @@
 	</array>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>음성 녹음을 위해 마이크 권한이 필요합니다.</string>
-	<key>ITSAppUsesNonExemptEncryption</key> <No>
+	<key>ITSAppUsesNonExemptEncryption</key> <false/>
 	<key>NSFileProviderDomainUsageDescription</key>
     <string>앱이 로컬 데이터베이스에 접근하여 데이터를 저장하고 읽기 위해 권한이 필요합니다.</string>
     <key>NSDocumentsFolderUsageDescription</key>

--- a/lib/pages/memo_page/widgets/recording_controller_box.dart
+++ b/lib/pages/memo_page/widgets/recording_controller_box.dart
@@ -51,7 +51,7 @@ class _RecordingControllerBoxState extends ConsumerState<RecordingControllerBox>
         child: CompositedTransformFollower(
           link: _layerLink,
           showWhenUnlinked: false,
-          offset: Offset(227, -230.0),
+          offset: Offset(227, -270.0),
           child: Material(
             borderRadius: BorderRadius.circular(8.0),
             elevation: 2.0,
@@ -115,6 +115,21 @@ class _RecordingControllerBoxState extends ConsumerState<RecordingControllerBox>
                 await recordingViewModel.transcribeRecording(
                   recording.path,
                   _mapLanguageToCode(_selectedLanguage),
+                  widget.controller!,
+                );
+              }
+            },
+          ),
+          _buildMenuItem(
+            context,
+            icon: Icons.summarize,
+            label: 'AI 요약',
+            onTap: () async {
+              _toggleMenu(context);
+              if (widget.controller != null) {
+                final recording = recordingState.recordings.last;
+                await recordingViewModel.summarizeRecording(
+                  recording.path,
                   widget.controller!,
                 );
               }

--- a/lib/services/gpt_service.dart
+++ b/lib/services/gpt_service.dart
@@ -25,7 +25,7 @@ class GptService {
           'messages': [
             {
               'role': 'system',
-              'content': 'You are an expert at formatting text into clean and readable Markdown. Convert the following text into well-structured Markdown format, using appropriate headers, lists, or other Markdown elements as needed.'
+              'content': 'You are an expert at formatting text. Take the following text and return it exactly as provided, without changing any words, punctuation, or content. Only add appropriate spacing and line breaks to make it more readable in Markdown format. Do not use headers, lists, or any other Markdown features unless they are explicitly present in the original text.'
             },
             {'role': 'user', 'content': text},
           ],

--- a/lib/services/gpt_service.dart
+++ b/lib/services/gpt_service.dart
@@ -1,0 +1,89 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class GptService {
+  static const String baseUrl = 'https://api.openai.com/v1';
+  final String apiKey = dotenv.env['OPENAI_GPT_API_KEY'] ?? '';
+
+  Future<String?> convertToMarkdown(String text) async {
+    if (apiKey.isEmpty) {
+      print('에러: OPENAI_GPT_API_KEY가 .env 파일에 설정되지 않았습니다.');
+      return null;
+    }
+
+    try {
+      final response = await http.post(
+        Uri.parse('$baseUrl/chat/completions'),
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer $apiKey',
+        },
+        body: jsonEncode({
+          'model': 'gpt-4o-mini',
+          'messages': [
+            {
+              'role': 'system',
+              'content': 'You are an expert at formatting text into clean and readable Markdown. Convert the following text into well-structured Markdown format, using appropriate headers, lists, or other Markdown elements as needed.'
+            },
+            {'role': 'user', 'content': text},
+          ],
+        }),
+      );
+
+      if (response.statusCode == 200) {
+        final data = jsonDecode(response.body);
+        return data['choices'][0]['message']['content'];
+      } else {
+        print('GPT Markdown 변환 실패: ${response.statusCode}');
+        print('에러 메시지: ${response.body}');
+        return null;
+      }
+    } catch (e) {
+      print('GPT Markdown 변환 중 예외 발생: $e');
+      return null;
+    }
+  }
+
+  Future<String?> summarizeToMarkdown(String text) async {
+    if (apiKey.isEmpty) {
+      print('에러: OPENAI_GPT_API_KEY가 .env 파일에 설정되지 않았습니다.');
+      return null;
+    }
+
+    try {
+      final response = await http.post(
+        Uri.parse('$baseUrl/chat/completions'),
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer $apiKey',
+        },
+        body: jsonEncode({
+          'model': 'gpt-4o-mini',
+          'messages': [
+            {
+              'role': 'system',
+              'content': 'You are an expert at summarizing text concisely. Summarize the following text into a brief, well-structured Markdown format, highlighting key points using headers, bullet points, or other Markdown elements.'
+            },
+            {'role': 'user', 'content': text},
+          ],
+        }),
+      );
+
+      if (response.statusCode == 200) {
+        final data = jsonDecode(response.body);
+        return data['choices'][0]['message']['content'];
+      } else {
+        print('GPT 요약 실패: ${response.statusCode}');
+        print('에러 메시지: ${response.body}');
+        return null;
+      }
+    } catch (e) {
+      print('GPT 요약 중 예외 발생: $e');
+      return null;
+    }
+  }
+}
+
+final gptServiceProvider = Provider<GptService>((ref) => GptService());


### PR DESCRIPTION
![Simulator Screenshot - iPhone 16 Plus - 2025-06-10 at 17 45 40](https://github.com/user-attachments/assets/41fa3b26-062c-4a29-9a0b-1a31415b7aaf)


수출관리규정을 Info.plist에 명시함으로써 TestFlight 배포 절차가 더 줄어들었습니다.

기존의 whisper api가 음성 파일을 가공되지 않은 텍스트로 전달 해 주던 형식에서, 2가지 프롬프트가 각자 적용된 gpt 서비스를 recording_viewmodel에 연결하여 마크다운 형식으로 가시성 있게 정리된 원문을 받아보는 기능과 요약 기능을 각자 추가하고, UI에 반영하였습니다. 

