### PR TITLE
Feat/splash

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1664,15 +1664,15 @@ SPEC CHECKSUMS:
   abseil: a05cc83bf02079535e17169a73c5be5ba47f714b
   AppAuth: d4f13a8fe0baf391b2108511793e4b479691fb73
   AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
-  audioplayers_darwin: 877d9a4d06331c5c374595e46e16453ac7eafa40
+  audioplayers_darwin: ccf9c770ee768abb07e26d90af093f7bab1c12ab
   BoringSSL-GRPC: dded2a44897e45f28f08ae87a55ee4bcd19bc508
-  cloud_firestore: 41c1ea0ea7b3f9b50a8fe27a59009b65b7ce7404
+  cloud_firestore: 5c68298ed4398ab73ca3333ab99699add650ec1c
   Firebase: 3435bc66b4d494c2f22c79fd3aae4c1db6662327
-  firebase_analytics: 6f88ffa3cb60c55a9d6364581585647fd003be1b
-  firebase_auth: d23897e53d1dd87f0617f4e8f346b81558b63adc
-  firebase_core: a861be150c0e7c6aecedde077968eb92cbf790b9
-  firebase_crashlytics: aa26a226ac9a7047f729701fd8a60028a21f84ac
-  firebase_storage: 103aa51ed4b64da7e9acc1b071461762f5762a16
+  firebase_analytics: 8f7800fc2abdbd78cd82e175f56303899b0f4ccf
+  firebase_auth: 20e8d19009af204039cd2de28a4e2e642e7aba93
+  firebase_core: 700bac7ed92bb754fd70fbf01d72b36ecdd6d450
+  firebase_crashlytics: d101fbdc2dba187f483f13ae3ce9281779d664db
+  firebase_storage: 17e3f7e7ee83680abb6aad6a28fe1404bf6b5a53
   FirebaseAnalytics: 630349facf4a114a0977e5d7570e104261973287
   FirebaseAppCheckInterop: a92ba81d0ee3c4cddb1a2e52c668ea51dc63c3ae
   FirebaseAuth: 175cb5503dfdb52191b8ff81cdd52c1d9dee9ac9
@@ -1689,11 +1689,11 @@ SPEC CHECKSUMS:
   FirebaseSharedSwift: bdd5c8674c4712a98e70287c936bc5cca5d640f6
   FirebaseStorage: 2a3e5402a565e06e121308dadfe0626976fd6b45
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  flutter_keyboard_visibility: 0339d06371254c3eb25eeb90ba8d17dca8f9c069
-  flutter_keyboard_visibility_temp_fork: 8a8809c4129e31d25fca77446e0f3fd548122ced
-  flutter_sound: 82aba29055d6feba684d08906e0623217b87bcd3
+  flutter_keyboard_visibility: 4625131e43015dbbe759d9b20daaf77e0e3f6619
+  flutter_keyboard_visibility_temp_fork: 95b2d534bacf6ac62e7fcbe5c2a9e2c2a17ce06f
+  flutter_sound: b9236a5875299aaa4cef1690afd2f01d52a3f890
   flutter_sound_core: 427465f72d07ab8c3edbe8ffdde709ddacd3763c
-  google_sign_in_ios: 7411fab6948df90490dc4620ecbcabdc3ca04017
+  google_sign_in_ios: b48bb9af78576358a168361173155596c845f0b9
   GoogleAppMeasurement: 0dfca1a4b534d123de3945e28f77869d10d0d600
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleSignIn: ce8c89bb9b37fb624b92e7514cc67335d1e277e4
@@ -1702,26 +1702,24 @@ SPEC CHECKSUMS:
   gRPC-Core: 860978b7db482de8b4f5e10677216309b5ff6330
   GTMAppAuth: f69bd07d68cd3b766125f7e072c45d7340dea0de
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
-  image_picker_ios: c560581cceedb403a6ff17f2f816d7fea1421fc1
-  kakao_flutter_sdk_common: 3dc8492c202af7853585d151490b1c5c6b7576cb
+  image_picker_ios: 7fe1ff8e34c1790d6fff70a32484959f563a928a
+  kakao_flutter_sdk_common: 600d55b532da0bd37268a529e1add49302477710
   leveldb-library: cc8b8f8e013647a295ad3f8cd2ddf49a6f19be19
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
-  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
-  permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
+  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
+  permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
-  quill_native_bridge_ios: 2b01d585fcc73d0f5eed78c0bd244ee564b06f5a
+  quill_native_bridge_ios: f47af4b14e7757968486641656c5d23250cee521
   RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba
-  share_plus: 8b6f8b3447e494cca5317c8c3073de39b3600d1f
-  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
-  sign_in_with_apple: f3bf75217ea4c2c8b91823f225d70230119b8440
-  sqflite_darwin: 5a7236e3b501866c1c9befc6771dfd73ffb8702d
-  url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
-  video_player_avfoundation: 7c6c11d8470e1675df7397027218274b6d2360b3
-  webview_flutter_wkwebview: a4af96a051138e28e29f60101d094683b9f82188
+  share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
+  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
+  sign_in_with_apple: c5dcc141574c8c54d5ac99dd2163c0c72ad22418
+  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
+  url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
+  video_player_avfoundation: 2cef49524dd1f16c5300b9cd6efd9611ce03639b
+  webview_flutter_wkwebview: 1821ceac936eba6f7984d89a9f3bcb4dea99ebb2
 
-
-PODFILE CHECKSUM: 3d3e1fae6499320e11d47e87e13df551e0e8b75f
-
+PODFILE CHECKSUM: 251cb053df7158f337c0712f2ab29f4e0fa474ce
 
 COCOAPODS: 1.16.2

--- a/lib/pages/login_page/login_page.dart
+++ b/lib/pages/login_page/login_page.dart
@@ -2,6 +2,7 @@ import 'dart:developer';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:nota_note/theme/pretendard_text_styles.dart';
 import 'package:nota_note/viewmodels/auth/apple_auth_viewmodel.dart';
 import 'package:nota_note/viewmodels/auth/google_auth_viewmodel.dart';
 import 'package:nota_note/viewmodels/auth/kakao_auth_viewmodel.dart';
@@ -142,12 +143,7 @@ class _LoginPageState extends ConsumerState<LoginPage> {
               alignment: Alignment.center,
               child: Text(
                 text,
-                style: TextStyle(
-                  color: textColor,
-                  fontWeight: FontWeight.bold,
-                  fontSize: 14,
-                  fontFamily: 'Pretendard',
-                ),
+                style: PretendardTextStyles.bodyS.copyWith(color: textColor),
               ),
             ),
             // 좌측 아이콘

--- a/lib/pages/login_page/login_page.dart
+++ b/lib/pages/login_page/login_page.dart
@@ -1,10 +1,7 @@
-// lib/pages/login_page/login_page.dart
-
 import 'dart:developer';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:nota_note/main.dart';
 import 'package:nota_note/viewmodels/auth/apple_auth_viewmodel.dart';
 import 'package:nota_note/viewmodels/auth/google_auth_viewmodel.dart';
 import 'package:nota_note/viewmodels/auth/kakao_auth_viewmodel.dart';
@@ -67,7 +64,6 @@ class _LoginPageState extends ConsumerState<LoginPage> {
                         context,
                         MaterialPageRoute(builder: (_) => OnBoardingPage()),
                         //MaterialPageRoute(builder: (_) => MyHomePage()),
-
                       );
                     },
                   ),
@@ -87,7 +83,6 @@ class _LoginPageState extends ConsumerState<LoginPage> {
                         context,
                         MaterialPageRoute(builder: (_) => OnBoardingPage()),
                         //MaterialPageRoute(builder: (_) => MyHomePage()),
-
                       );
                     },
                   ),
@@ -106,7 +101,6 @@ class _LoginPageState extends ConsumerState<LoginPage> {
                         context,
                         MaterialPageRoute(builder: (_) => OnBoardingPage()),
                         //MaterialPageRoute(builder: (_) => MyHomePage()),
-
                       );
                     },
                   ),

--- a/lib/pages/login_page/shared_prefs_helper.dart
+++ b/lib/pages/login_page/shared_prefs_helper.dart
@@ -30,3 +30,13 @@ Future<void> clearLoginInfo() async {
   await prefs.remove('userId');
   await prefs.remove('loginProvider');
 }
+
+Future<void> saveAppleUserIdentifier(String userIdentifier) async {
+  final prefs = await SharedPreferences.getInstance();
+  await prefs.setString('apple_user_identifier', userIdentifier);
+}
+
+Future<String?> getAppleUserIdentifier() async {
+  final prefs = await SharedPreferences.getInstance();
+  return prefs.getString('apple_user_identifier');
+}

--- a/lib/pages/setting_page/settings_page.dart
+++ b/lib/pages/setting_page/settings_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:nota_note/pages/user_profile_page/user_profile_page.dart';
+import 'package:nota_note/theme/pretendard_text_styles.dart';
 import 'package:nota_note/viewmodels/auth/auth_common.dart' hide userIdProvider;
 import 'package:nota_note/viewmodels/auth/user_id_provider.dart';
 
@@ -17,14 +18,9 @@ class SettingsPage extends ConsumerWidget {
     return Scaffold(
       backgroundColor: Colors.white,
       appBar: AppBar(
-        title: const Text(
+        title: Text(
           '설정',
-          style: TextStyle(
-            fontSize: 18,
-            color: Colors.black,
-            fontWeight: FontWeight.w200,
-            fontFamily: 'Pretendard',
-          ),
+          style: PretendardTextStyles.titleS.copyWith(color: Colors.grey[900]),
         ),
         centerTitle: true,
         elevation: 0,
@@ -142,12 +138,7 @@ class _SettingsTile extends StatelessWidget {
       ),
       title: Text(
         label,
-        style: TextStyle(
-          color: Colors.grey[900], // 텍스트 색상: gray.900
-          fontSize: 16,
-          fontFamily: 'Pretendard',
-          fontWeight: FontWeight.w100,
-        ),
+        style: PretendardTextStyles.bodyS.copyWith(color: Colors.grey[900]),
       ),
       onTap: onTap,
     );

--- a/lib/pages/setting_page/settings_page.dart
+++ b/lib/pages/setting_page/settings_page.dart
@@ -2,13 +2,16 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:nota_note/pages/user_profile_page/user_profile_page.dart';
-import 'package:nota_note/viewmodels/auth/auth_common.dart';
+import 'package:nota_note/viewmodels/auth/auth_common.dart' hide userIdProvider;
+import 'package:nota_note/viewmodels/auth/user_id_provider.dart';
 
+/// 설정 페이지
 class SettingsPage extends ConsumerWidget {
   const SettingsPage({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    // 현재 로그인된 사용자 ID 읽기 (초기값은 userIdProvider에서 가져오지만, 아래서 실시간 갱신함)
     final userId = ref.watch(userIdProvider);
 
     return Scaffold(
@@ -25,7 +28,7 @@ class SettingsPage extends ConsumerWidget {
         ),
         centerTitle: true,
         elevation: 0,
-        iconTheme: IconThemeData(color: Colors.grey[700]), // 뒤로가기 아이콘
+        iconTheme: IconThemeData(color: Colors.grey[700]), // 뒤로가기 아이콘 색상
       ),
       body: Column(
         children: [
@@ -34,55 +37,71 @@ class SettingsPage extends ConsumerWidget {
             child: ListView(
               padding: const EdgeInsets.symmetric(vertical: 8),
               children: [
+                // 프로필 설정
                 _SettingsTile(
                   label: '프로필',
                   iconPath: 'assets/icons/User.svg',
-                  onTap: () {
-                    if (userId != null) {
+                  onTap: () async {
+                    // userIdProvider 상태를 강제로 최신화 (시뮬레이터 재시작 시에도 대응)
+                    final latestUserId = await getCurrentUserId();
+                    ref.read(userIdProvider.notifier).state = latestUserId;
+
+                    // 최신 userId 기준으로 프로필 페이지 이동
+                    if (latestUserId != null && latestUserId.isNotEmpty) {
                       Navigator.push(
                         context,
                         MaterialPageRoute(
-                          builder: (_) => UserProfilePage(userId: userId),
+                          builder: (_) => UserProfilePage(userId: latestUserId),
                         ),
+                      );
+                    } else {
+                      // 로딩 중 또는 null일 경우 스낵바 표시
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('사용자 정보를 불러오는 중입니다.')),
                       );
                     }
                   },
                 ),
+                // 알림 설정
                 _SettingsTile(
                   label: '알림',
                   iconPath: 'assets/icons/MagnifyingGlass.svg',
                   onTap: () {
-                    // 알림 설정 페이지 이동
+                    // 알림 설정 페이지 이동 예정
                   },
                 ),
+                // 테마 설정
                 _SettingsTile(
                   label: '테마 설정',
                   iconPath: 'assets/icons/Monitor.svg',
                   onTap: () {
-                    // 테마 설정 페이지 이동
+                    // 테마 설정 페이지 이동 예정
                   },
                 ),
+                // 암호 설정
                 _SettingsTile(
                   label: '암호',
                   iconPath: 'assets/icons/LockSimple.svg',
                   onTap: () {
-                    // 암호 설정 이동
+                    // 암호 설정 페이지 이동 예정
                   },
                 ),
+                // 이용약관
                 _SettingsTile(
                   label: '이용약관 및 개인정보 정책',
                   iconPath: 'assets/icons/Info.svg',
                   onTap: () {
-                    // 약관 페이지 이동
+                    // 약관 페이지 이동 예정
                   },
                 ),
               ],
             ),
           ),
+          // 하단 앱 버전 표시
           const Padding(
             padding: EdgeInsets.symmetric(vertical: 24),
             child: Text(
-              '버전 0.0.0', //현재 버전 표시로 바꾸기
+              '버전 0.0.0', // 추후 현재 앱 버전으로 표시할 예정
               style: TextStyle(
                 fontSize: 12,
                 color: Color(0xFF666666),
@@ -96,7 +115,7 @@ class SettingsPage extends ConsumerWidget {
   }
 }
 
-// 공통 설정 항목 위젯
+/// 공통 설정 항목 위젯
 class _SettingsTile extends StatelessWidget {
   final String label;
   final String iconPath;
@@ -124,10 +143,11 @@ class _SettingsTile extends StatelessWidget {
       title: Text(
         label,
         style: TextStyle(
-            color: Colors.grey[900], // 텍스트 색상: gray.900
-            fontSize: 16,
-            fontFamily: 'Pretendard',
-            fontWeight: FontWeight.w100),
+          color: Colors.grey[900], // 텍스트 색상: gray.900
+          fontSize: 16,
+          fontFamily: 'Pretendard',
+          fontWeight: FontWeight.w100,
+        ),
       ),
       onTap: onTap,
     );

--- a/lib/pages/splash_page/splash_page.dart
+++ b/lib/pages/splash_page/splash_page.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nota_note/pages/login_page/login_page.dart';
-import 'package:nota_note/pages/my_home_page/my_home_page.dart';
 import 'package:nota_note/viewmodels/auth/auth_common.dart';
 import 'package:nota_note/providers/user_profile_provider.dart';
 import 'package:nota_note/pages/on_boarding_page/on_boarding_page.dart';
@@ -22,14 +21,16 @@ class _SplashPageState extends ConsumerState<SplashPage> {
     _checkAuthAndNavigate();
   }
 
-  /// 로그인 여부 확인 → 로그인 / 홈 화면 분기
+  /// 로그인 여부 확인 → 로그인 or 홈 화면 분기
   Future<void> _checkAuthAndNavigate() async {
     await Future.delayed(const Duration(seconds: 2)); // 스플래시 유지 시간
 
-    final userId = await getCurrentUserId();
+    // 세션 유효성을 고려한 userId 조회 (google은 유지, kakao는 세션 검사, apple은 무조건 null)
+    final userId = await getCurrentUserId(appLaunch: true);
     if (!mounted) return;
 
     if (userId == null) {
+      // 세션 없음 → 로그인 페이지로 이동
       Navigator.pushReplacement(
         context,
         MaterialPageRoute(builder: (_) => const LoginPage()),
@@ -37,16 +38,18 @@ class _SplashPageState extends ConsumerState<SplashPage> {
       return;
     }
 
+    // 세션 있음 → 해당 userId로 사용자 정보 로딩
     final userAsync = await ref.read(userProfileProvider(userId).future);
-
     if (!mounted) return;
 
     if (userAsync == null) {
+      // Firestore에 사용자 정보 없음 → 로그인 페이지로 이동
       Navigator.pushReplacement(
         context,
         MaterialPageRoute(builder: (_) => const LoginPage()),
       );
     } else {
+      // Firestore에 사용자 정보 있음 → 온보딩 페이지로 이동
       Navigator.pushReplacement(
         context,
         MaterialPageRoute(builder: (_) => const OnBoardingPage()),

--- a/lib/pages/user_profile_page/user_profile_edit_page.dart
+++ b/lib/pages/user_profile_page/user_profile_edit_page.dart
@@ -1,10 +1,9 @@
-// lib/pages/user_profile_page/user_profile_edit_page.dart
-
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:nota_note/models/user_model.dart';
 import 'package:nota_note/pages/login_page/login_page.dart';
 import 'package:nota_note/pages/user_profile_page/widgets/profile_image_widget.dart';
+import 'package:nota_note/theme/pretendard_text_styles.dart';
 import 'package:nota_note/viewmodels/auth/auth_common.dart';
 import 'package:nota_note/viewmodels/user_profile_viewmodel.dart';
 
@@ -23,8 +22,8 @@ class _UserProfileEditPageState extends State<UserProfileEditPage> {
   late TextEditingController _emailController;
   late TextEditingController _nameController;
 
-  final FocusNode _nameFocusNode = FocusNode(); // 추가
-  final FocusNode _emailFocusNode = FocusNode(); // 추가
+  final FocusNode _nameFocusNode = FocusNode();
+  final FocusNode _emailFocusNode = FocusNode();
 
   @override
   void initState() {
@@ -37,27 +36,23 @@ class _UserProfileEditPageState extends State<UserProfileEditPage> {
   void dispose() {
     _emailController.dispose();
     _nameController.dispose();
-    _nameFocusNode.dispose(); // 해제
-    _emailFocusNode.dispose(); // 해제
+    _nameFocusNode.dispose();
+    _emailFocusNode.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      behavior: HitTestBehavior.opaque, // 키보드 문제 방지
+      behavior: HitTestBehavior.opaque,
       onTap: () => FocusScope.of(context).unfocus(),
       child: Scaffold(
         appBar: AppBar(
           leading: const BackButton(color: Colors.grey),
           title: Text(
             '프로필',
-            style: TextStyle(
-              fontSize: 18,
-              fontWeight: FontWeight.w500,
-              fontFamily: 'Pretendard',
-              color: Colors.grey[900],
-            ),
+            style:
+                PretendardTextStyles.titleS.copyWith(color: Colors.grey[900]),
           ),
           centerTitle: true,
           backgroundColor: Colors.white,
@@ -75,16 +70,13 @@ class _UserProfileEditPageState extends State<UserProfileEditPage> {
                 );
 
                 if (mounted) {
-                  Navigator.pop(context, true); // true 전달
+                  Navigator.pop(context, true);
                 }
               },
               child: Text(
                 '완료',
-                style: TextStyle(
-                  color: Colors.grey[700],
-                  fontWeight: FontWeight.w500,
-                  fontSize: 14,
-                ),
+                style: PretendardTextStyles.bodyM
+                    .copyWith(color: Colors.grey[700]),
               ),
             ),
           ],
@@ -98,7 +90,7 @@ class _UserProfileEditPageState extends State<UserProfileEditPage> {
               children: [
                 const SizedBox(height: 24),
 
-                // 프로필 이미지 수정 가능
+                // 프로필 이미지
                 Center(
                   child: Stack(
                     alignment: Alignment.center,
@@ -122,8 +114,7 @@ class _UserProfileEditPageState extends State<UserProfileEditPage> {
                           ),
                           child: Center(
                             child: SvgPicture.asset(
-                              'assets/icons/ProfileCamera.svg',
-                            ),
+                                'assets/icons/ProfileCamera.svg'),
                           ),
                         ),
                       ),
@@ -138,16 +129,9 @@ class _UserProfileEditPageState extends State<UserProfileEditPage> {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      // 닉네임
-                      Text(
-                        '닉네임',
-                        style: TextStyle(
-                          color: Colors.grey[800],
-                          fontWeight: FontWeight.bold,
-                          fontSize: 16,
-                          fontFamily: 'Pretendard',
-                        ),
-                      ),
+                      Text('닉네임',
+                          style: PretendardTextStyles.bodyMEmphasis
+                              .copyWith(color: Colors.grey[800])),
                       const SizedBox(height: 8),
                       Stack(
                         alignment: Alignment.centerRight,
@@ -156,11 +140,8 @@ class _UserProfileEditPageState extends State<UserProfileEditPage> {
                             focusNode: _nameFocusNode,
                             controller: _nameController,
                             maxLength: 10,
-                            style: TextStyle(
-                              fontSize: 16,
-                              color: Colors.grey[900],
-                              fontFamily: 'Pretendard',
-                            ),
+                            style: PretendardTextStyles.bodyM
+                                .copyWith(color: Colors.grey[900]),
                             decoration: InputDecoration(
                               counterText: '',
                               contentPadding: const EdgeInsets.symmetric(
@@ -186,37 +167,22 @@ class _UserProfileEditPageState extends State<UserProfileEditPage> {
                             right: 16,
                             child: Text(
                               '${_nameController.text.length}/10',
-                              style: TextStyle(
-                                fontSize: 12,
-                                color: Colors.grey[500],
-                                fontFamily: 'Pretendard',
-                              ),
+                              style: PretendardTextStyles.labelS
+                                  .copyWith(color: Colors.grey[400]),
                             ),
                           ),
                         ],
                       ),
-
                       const SizedBox(height: 24),
-
-                      // 이메일
-                      Text(
-                        '이메일',
-                        style: TextStyle(
-                          color: Colors.grey[800],
-                          fontWeight: FontWeight.bold,
-                          fontSize: 16,
-                          fontFamily: 'Pretendard',
-                        ),
-                      ),
+                      Text('이메일',
+                          style: PretendardTextStyles.bodyMEmphasis
+                              .copyWith(color: Colors.grey[800])),
                       const SizedBox(height: 8),
                       TextFormField(
                         focusNode: _emailFocusNode,
                         controller: _emailController,
-                        style: TextStyle(
-                          fontSize: 16,
-                          color: Colors.grey[900],
-                          fontFamily: 'Pretendard',
-                        ),
+                        style: PretendardTextStyles.bodyM
+                            .copyWith(color: Colors.grey[900]),
                         decoration: InputDecoration(
                           contentPadding: const EdgeInsets.symmetric(
                               horizontal: 16, vertical: 14),
@@ -242,22 +208,15 @@ class _UserProfileEditPageState extends State<UserProfileEditPage> {
                 const SizedBox(height: 24),
                 Divider(color: Colors.grey[200], thickness: 6),
 
-                // 계정 전환
                 Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 20),
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       const SizedBox(height: 18),
-                      Text(
-                        '계정 전환',
-                        style: TextStyle(
-                          fontSize: 14,
-                          fontWeight: FontWeight.w400,
-                          fontFamily: 'Pretendard',
-                          color: Colors.grey[900],
-                        ),
-                      ),
+                      Text('계정 전환',
+                          style: PretendardTextStyles.labelM
+                              .copyWith(color: Colors.grey[900])),
                       const SizedBox(height: 14),
                     ],
                   ),
@@ -271,14 +230,9 @@ class _UserProfileEditPageState extends State<UserProfileEditPage> {
                   ),
                   title: Text(
                     widget.user.email,
-                    style: TextStyle(
-                      fontFamily: 'Pretendard',
-                      fontSize: 16,
-                      fontWeight: FontWeight.w500,
-                      color: Colors.grey[900],
-                    ),
+                    style: PretendardTextStyles.bodyM
+                        .copyWith(color: Colors.grey[900]),
                   ),
-                  onTap: () {},
                 ),
 
                 ListTile(
@@ -288,27 +242,18 @@ class _UserProfileEditPageState extends State<UserProfileEditPage> {
                       color: Colors.grey[200],
                       borderRadius: BorderRadius.circular(16),
                     ),
-                    child: SvgPicture.asset(
-                      'assets/icons/Plus.svg',
-                      width: 20,
-                      height: 20,
-                    ),
+                    child: SvgPicture.asset('assets/icons/Plus.svg',
+                        width: 20, height: 20),
                   ),
                   title: Text(
                     '계정 추가하기',
-                    style: TextStyle(
-                      fontFamily: 'Pretendard',
-                      fontSize: 16,
-                      fontWeight: FontWeight.w500,
-                      color: Colors.grey[900],
-                    ),
+                    style: PretendardTextStyles.bodyM
+                        .copyWith(color: Colors.grey[900]),
                   ),
-                  onTap: () {},
                 ),
 
                 Divider(color: Colors.grey[200], thickness: 6),
 
-                // 로그아웃/탈퇴
                 Padding(
                   padding:
                       const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
@@ -329,24 +274,16 @@ class _UserProfileEditPageState extends State<UserProfileEditPage> {
                         },
                         child: Text(
                           '로그아웃',
-                          style: TextStyle(
-                            fontFamily: 'Pretendard',
-                            fontSize: 16,
-                            fontWeight: FontWeight.w500,
-                            color: Colors.grey[900],
-                          ),
+                          style: PretendardTextStyles.bodyM
+                              .copyWith(color: Colors.grey[900]),
                         ),
                       ),
                       const SizedBox(height: 100),
-                      const Center(
+                      Center(
                         child: Text(
                           '계정 탈퇴하기',
-                          style: TextStyle(
-                            fontFamily: 'Pretendard',
-                            fontSize: 14,
-                            fontWeight: FontWeight.w500,
-                            color: Color(0xFFFF2F2F),
-                          ),
+                          style: PretendardTextStyles.bodyS
+                              .copyWith(color: Colors.red),
                         ),
                       ),
                     ],

--- a/lib/pages/user_profile_page/user_profile_page.dart
+++ b/lib/pages/user_profile_page/user_profile_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:nota_note/pages/login_page/login_page.dart';
 import 'package:nota_note/pages/user_profile_page/user_profile_edit_page.dart';
+import 'package:nota_note/theme/pretendard_text_styles.dart';
 import 'package:nota_note/viewmodels/auth/auth_common.dart';
 import 'package:nota_note/pages/user_profile_page/widgets/profile_image_widget.dart';
 import 'package:nota_note/providers/user_profile_provider.dart';
@@ -23,10 +24,7 @@ class UserProfilePage extends ConsumerWidget {
         leading: const BackButton(color: Colors.grey),
         title: Text(
           '프로필',
-          style: TextStyle(
-            fontSize: 18,
-            fontWeight: FontWeight.w500,
-            fontFamily: 'Pretendard',
+          style: PretendardTextStyles.titleS.copyWith(
             color: Colors.grey[900],
           ),
         ),
@@ -57,10 +55,8 @@ class UserProfilePage extends ConsumerWidget {
             },
             child: Text(
               '수정',
-              style: TextStyle(
+              style: PretendardTextStyles.bodyM.copyWith(
                 color: Colors.grey[700],
-                fontWeight: FontWeight.w200,
-                fontSize: 16,
               ),
             ),
           )
@@ -123,11 +119,8 @@ class UserProfilePage extends ConsumerWidget {
                     children: [
                       Text(
                         '닉네임',
-                        style: TextStyle(
+                        style: PretendardTextStyles.bodyMEmphasis.copyWith(
                           color: Colors.grey[800],
-                          fontWeight: FontWeight.bold,
-                          fontSize: 16,
-                          fontFamily: 'Pretendard',
                         ),
                       ),
                       const SizedBox(height: 8),
@@ -142,9 +135,7 @@ class UserProfilePage extends ConsumerWidget {
                         ),
                         child: Text(
                           user.displayName,
-                          style: TextStyle(
-                            fontSize: 16,
-                            fontFamily: 'Pretendard',
+                          style: PretendardTextStyles.bodyM.copyWith(
                             color: Colors.grey[900],
                           ),
                         ),
@@ -152,11 +143,8 @@ class UserProfilePage extends ConsumerWidget {
                       const SizedBox(height: 24),
                       Text(
                         '이메일',
-                        style: TextStyle(
+                        style: PretendardTextStyles.bodyMEmphasis.copyWith(
                           color: Colors.grey[800],
-                          fontWeight: FontWeight.bold,
-                          fontSize: 16,
-                          fontFamily: 'Pretendard',
                         ),
                       ),
                       const SizedBox(height: 8),
@@ -171,9 +159,7 @@ class UserProfilePage extends ConsumerWidget {
                         ),
                         child: Text(
                           user.email,
-                          style: TextStyle(
-                            fontSize: 16,
-                            fontFamily: 'Pretendard',
+                          style: PretendardTextStyles.bodyM.copyWith(
                             color: Colors.grey[900],
                           ),
                         ),
@@ -193,10 +179,7 @@ class UserProfilePage extends ConsumerWidget {
                       const SizedBox(height: 18),
                       Text(
                         '계정 전환',
-                        style: TextStyle(
-                          fontSize: 14,
-                          fontWeight: FontWeight.w400,
-                          fontFamily: 'Pretendard',
+                        style: PretendardTextStyles.labelM.copyWith(
                           color: Colors.grey[900],
                         ),
                       ),
@@ -213,10 +196,7 @@ class UserProfilePage extends ConsumerWidget {
                   ),
                   title: Text(
                     user.email,
-                    style: TextStyle(
-                      fontSize: 16,
-                      fontWeight: FontWeight.w500,
-                      fontFamily: 'Pretendard',
+                    style: PretendardTextStyles.bodyM.copyWith(
                       color: Colors.grey[900],
                     ),
                   ),
@@ -237,10 +217,7 @@ class UserProfilePage extends ConsumerWidget {
                   ),
                   title: Text(
                     '계정 추가하기',
-                    style: TextStyle(
-                      fontSize: 16,
-                      fontWeight: FontWeight.w500,
-                      fontFamily: 'Pretendard',
+                    style: PretendardTextStyles.bodyM.copyWith(
                       color: Colors.grey[900],
                     ),
                   ),
@@ -268,23 +245,17 @@ class UserProfilePage extends ConsumerWidget {
                         },
                         child: Text(
                           '로그아웃',
-                          style: TextStyle(
-                            fontSize: 16,
-                            fontWeight: FontWeight.w500,
-                            fontFamily: 'Pretendard',
+                          style: PretendardTextStyles.bodyM.copyWith(
                             color: Colors.grey[900],
                           ),
                         ),
                       ),
                       const SizedBox(height: 100),
-                      const Center(
+                      Center(
                         child: Text(
                           '계정 탈퇴하기',
-                          style: TextStyle(
-                            fontSize: 14,
-                            fontWeight: FontWeight.w500,
-                            fontFamily: 'Pretendard',
-                            color: Color(0xFFFF2F2F),
+                          style: PretendardTextStyles.bodyS.copyWith(
+                            color: Colors.red,
                           ),
                         ),
                       ),

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -4,8 +4,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nota_note/pages/login_page/shared_prefs_helper.dart';
 import 'package:nota_note/viewmodels/auth/user_id_provider.dart';
 
-import '../pages/login_page/shared_prefs_helper.dart';
-
 class AuthService {
   final FirebaseAuth _auth = FirebaseAuth.instance;
 

--- a/lib/viewmodels/auth/apple_auth_viewmodel.dart
+++ b/lib/viewmodels/auth/apple_auth_viewmodel.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
-import 'dart:math';
+import 'dart:developer';
+import 'dart:math' hide log;
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:crypto/crypto.dart';
 import 'package:firebase_auth/firebase_auth.dart';
@@ -11,37 +12,41 @@ import 'package:nota_note/models/user_model.dart';
 import 'package:nota_note/pages/login_page/shared_prefs_helper.dart';
 import 'package:nota_note/viewmodels/auth/auth_common.dart';
 
-// Apple 로그인 ViewModel을 Provider로 등록
+/// Apple 로그인 ViewModel을 Provider로 등록
 final appleAuthViewModelProvider = Provider<AppleAuthViewModel>(
-  (ref) => AppleAuthViewModel(),
+  (ref) => AppleAuthViewModel(ref),
 );
 
+/// Apple 로그인 기능을 담당하는 ViewModel
 class AppleAuthViewModel {
+  final Ref ref;
+  AppleAuthViewModel(this.ref);
+
   // Firebase 인증 및 Firestore 인스턴스 초기화
   final FirebaseAuth _auth = FirebaseAuth.instance;
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
 
-  // Apple 로그인 메서드
+  /// Apple 로그인 메서드
   Future<UserModel?> signInWithApple() async {
     try {
       // 로그인 요청 시 nonce 생성 (재사용 공격 방지)
-      print('[AppleLogin] nonce 생성 중...');
+      log('[AppleLogin] nonce 생성 중...');
       final rawNonce = _generateNonce();
       final hashedNonce = _sha256ofString(rawNonce);
-      print('[AppleLogin] rawNonce: $rawNonce');
-      print('[AppleLogin] hashedNonce: $hashedNonce');
+      log('[AppleLogin] rawNonce: $rawNonce');
+      log('[AppleLogin] hashedNonce: $hashedNonce');
 
       // .env 파일에서 clientId, redirectUri 가져오기
       final clientId = dotenv.env['APPLE_CLIENT_ID'];
       final redirectUri = dotenv.env['APPLE_REDIRECT_URI'];
       if (clientId == null || redirectUri == null) {
-        print('[AppleLogin] 경고: .env 환경 변수 누락됨');
+        log('[AppleLogin] 경고: .env 환경 변수 누락됨');
         return null;
       }
 
-      print('[AppleLogin] Apple 로그인 요청...');
-      print('[AppleLogin] .env clientId: $clientId');
-      print('[AppleLogin] .env redirectUri: $redirectUri');
+      log('[AppleLogin] Apple 로그인 요청...');
+      log('[AppleLogin] .env clientId: $clientId');
+      log('[AppleLogin] .env redirectUri: $redirectUri');
 
       // Apple 인증 요청
       final credential = await SignInWithApple.getAppleIDCredential(
@@ -49,57 +54,54 @@ class AppleAuthViewModel {
           AppleIDAuthorizationScopes.email,
           AppleIDAuthorizationScopes.fullName,
         ],
-        // nonce: hashedNonce,
+        // nonce: hashedNonce,  // 보안을 강화하고 싶다면 주석 해제
       );
 
       // Apple에서 받은 정보 출력
-      print('[AppleLogin] identityToken: ${credential.identityToken}');
-      print('[AppleLogin] authorizationCode: ${credential.authorizationCode}');
-      print('[AppleLogin] userIdentifier: ${credential.userIdentifier}');
-      print('[AppleLogin] email: ${credential.email}');
-      print('[AppleLogin] givenName: ${credential.givenName}');
-      print('[AppleLogin] familyName: ${credential.familyName}');
+      log('[AppleLogin] identityToken: ${credential.identityToken}');
+      log('[AppleLogin] authorizationCode: ${credential.authorizationCode}');
+      log('[AppleLogin] userIdentifier: ${credential.userIdentifier}');
+      log('[AppleLogin] email: ${credential.email}');
+      log('[AppleLogin] givenName: ${credential.givenName}');
+      log('[AppleLogin] familyName: ${credential.familyName}');
 
       // 토큰 길이 확인 (디버깅용)
-      print('[AppleLogin] 인증 토큰 길이: ${credential.identityToken?.length}');
-      print('[AppleLogin] 인증 코드 길이: ${credential.authorizationCode?.length}');
+      log('[AppleLogin] 인증 토큰 길이: ${credential.identityToken?.length}');
+      log('[AppleLogin] 인증 코드 길이: ${credential.authorizationCode?.length}');
 
       // identityToken이 없으면 중단
       if (credential.identityToken == null) {
-        final msg = '[AppleLogin] 오류: identityToken이 null입니다.';
-        print(msg);
+        log('[AppleLogin] 오류: identityToken이 null입니다.');
         return null;
       }
 
       // Apple로 받은 토큰을 이용해 Firebase OAuth 자격 증명 생성
-      print('[AppleLogin] Firebase OAuthCredential 생성...');
+      log('[AppleLogin] Firebase OAuthCredential 생성...');
       final oauthCredential = OAuthProvider("apple.com").credential(
-          idToken: credential.identityToken,
-          accessToken: credential.authorizationCode
-          // rawNonce: rawNonce,
-          );
+        idToken: credential.identityToken,
+        accessToken: credential.authorizationCode,
+        // rawNonce: rawNonce, // 보안을 강화하고 싶다면 주석 해제
+      );
 
       // Firebase 인증 시도
-      print('[AppleLogin] FirebaseAuth 인증 시도...');
+      log('[AppleLogin] FirebaseAuth 인증 시도...');
       final UserCredential userCredential;
       try {
         userCredential = await _auth.signInWithCredential(oauthCredential);
       } catch (e, stack) {
-        print('[AppleLogin] Firebase 인증 예외 발생: $e');
+        log('[AppleLogin] Firebase 인증 예외 발생: $e');
         return null;
       }
 
       // 인증된 사용자 정보 가져오기
       final user = userCredential.user;
       if (user == null) {
-        final msg = '[AppleLogin] Firebase 인증 실패: user == null';
-        print(msg);
+        log('[AppleLogin] Firebase 인증 실패: user == null');
         return null;
       }
 
       // Firebase 인증 성공 로그
-      print(
-          '[AppleLogin] Firebase 로그인 성공: uid=${user.uid}, email=${user.email}');
+      log('[AppleLogin] Firebase 로그인 성공: uid=${user.uid}, email=${user.email}');
 
       // 사용자 정보 정리
       final userId = user.uid;
@@ -114,7 +116,7 @@ class AppleAuthViewModel {
 
       // 문서가 없으면 신규 사용자로 등록
       if (!userDoc.exists) {
-        print('[AppleLogin] Firestore 신규 유저 저장...');
+        log('[AppleLogin] Firestore 신규 유저 저장...');
         final userModel = UserModel(
           userId: userId,
           email: email,
@@ -127,28 +129,31 @@ class AppleAuthViewModel {
         );
         await docRef.set(userModel.toJson());
       } else {
-        print('[AppleLogin] 기존 유저 문서 존재함');
+        log('[AppleLogin] 기존 유저 문서 존재함');
       }
 
       // SharedPreferences에 로그인 정보 저장
       await saveLoginUserId(userId);
       await saveLoginProvider('apple');
 
+      //로그인 성공 후 userIdProvider 상태 갱신
+      ref.read(userIdProvider.notifier).state = userId;
+
       // 최신 사용자 정보 가져오기
       final freshDoc = await docRef.get();
-      print('[AppleLogin] 로그인 최종 성공 → UserModel 반환');
+      log('[AppleLogin] 로그인 최종 성공 → UserModel 반환');
 
       // 최종적으로 UserModel 반환
       return UserModel.fromJson(freshDoc.data()!);
     } catch (e, stack) {
       // 전체 예외 캐치
-      print('[AppleLogin] 오류 발생: $e');
-      print('[AppleLogin] 스택트레이스:\n$stack');
+      log('[AppleLogin] 오류 발생: $e');
+      log('[AppleLogin] 스택트레이스:\n$stack');
       return null;
     }
   }
 
-  // nonce 생성기 (랜덤 문자열)
+  /// nonce 생성기 (랜덤 문자열)
   String _generateNonce([int length = 32]) {
     final charset =
         '0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._';
@@ -157,7 +162,7 @@ class AppleAuthViewModel {
         .join();
   }
 
-  // SHA256 해싱 함수
+  /// SHA256 해싱 함수
   String _sha256ofString(String input) {
     final bytes = utf8.encode(input);
     final digest = sha256.convert(bytes);

--- a/lib/viewmodels/auth/apple_auth_viewmodel.dart
+++ b/lib/viewmodels/auth/apple_auth_viewmodel.dart
@@ -6,6 +6,7 @@ import 'package:crypto/crypto.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:nota_note/viewmodels/auth/user_id_provider.dart';
 import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 
 import 'package:nota_note/models/user_model.dart';
@@ -67,7 +68,7 @@ class AppleAuthViewModel {
 
       // 토큰 길이 확인 (디버깅용)
       log('[AppleLogin] 인증 토큰 길이: ${credential.identityToken?.length}');
-      log('[AppleLogin] 인증 코드 길이: ${credential.authorizationCode?.length}');
+      log('[AppleLogin] 인증 코드 길이: ${credential.authorizationCode.length}');
 
       // identityToken이 없으면 중단
       if (credential.identityToken == null) {
@@ -88,7 +89,7 @@ class AppleAuthViewModel {
       final UserCredential userCredential;
       try {
         userCredential = await _auth.signInWithCredential(oauthCredential);
-      } catch (e, stack) {
+      } catch (e) {
         log('[AppleLogin] Firebase 인증 예외 발생: $e');
         return null;
       }
@@ -135,6 +136,9 @@ class AppleAuthViewModel {
       // SharedPreferences에 로그인 정보 저장
       await saveLoginUserId(userId);
       await saveLoginProvider('apple');
+      if (credential.userIdentifier != null) {
+        await saveAppleUserIdentifier(credential.userIdentifier!);
+      }
 
       //로그인 성공 후 userIdProvider 상태 갱신
       ref.read(userIdProvider.notifier).state = userId;

--- a/lib/viewmodels/auth/google_auth_viewmodel.dart
+++ b/lib/viewmodels/auth/google_auth_viewmodel.dart
@@ -1,4 +1,3 @@
-// viewmodels/auth/google_auth_viewmodel.dart
 import 'dart:developer';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';

--- a/lib/viewmodels/auth/google_auth_viewmodel.dart
+++ b/lib/viewmodels/auth/google_auth_viewmodel.dart
@@ -6,6 +6,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:nota_note/models/user_model.dart';
 import 'package:nota_note/pages/login_page/shared_prefs_helper.dart';
 import 'package:nota_note/viewmodels/auth/auth_common.dart';
+import 'package:nota_note/viewmodels/auth/user_id_provider.dart';
 
 final googleAuthViewModelProvider =
     Provider<GoogleAuthViewModel>((ref) => GoogleAuthViewModel(ref));

--- a/lib/viewmodels/auth/kakao_auth_viewmodel.dart
+++ b/lib/viewmodels/auth/kakao_auth_viewmodel.dart
@@ -1,4 +1,3 @@
-// viewmodels/auth/kakao_auth_viewmodel.dart
 import 'dart:developer';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';

--- a/lib/viewmodels/auth/kakao_auth_viewmodel.dart
+++ b/lib/viewmodels/auth/kakao_auth_viewmodel.dart
@@ -5,6 +5,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:nota_note/models/user_model.dart';
 import 'package:nota_note/pages/login_page/shared_prefs_helper.dart';
 import 'package:nota_note/viewmodels/auth/auth_common.dart';
+import 'package:nota_note/viewmodels/auth/user_id_provider.dart';
 
 final kakaoAuthViewModelProvider =
     Provider<KakaoAuthViewModel>((ref) => KakaoAuthViewModel(ref));

--- a/lib/viewmodels/auth/user_id_provider.dart
+++ b/lib/viewmodels/auth/user_id_provider.dart
@@ -1,5 +1,9 @@
-// providers/user_id_provider.dart
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:nota_note/viewmodels/auth/auth_common.dart';
 
-/// 현재 로그인된 사용자 ID를 저장하는 StateProvider
 final userIdProvider = StateProvider<String?>((ref) => null);
+
+final currentUserInitProvider = FutureProvider<void>((ref) async {
+  final id = await getCurrentUserId();
+  ref.read(userIdProvider.notifier).state = id;
+});

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1158,7 +1158,7 @@ packages:
     source: hosted
     version: "6.0.0"
   shared_preferences:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: shared_preferences
       sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
   sign_in_with_apple: ^7.0.1
   timeago: ^3.7.1
   intl: ^0.20.2
+  shared_preferences: ^2.5.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- 로그인 계정 전환 시 이전 정보가 유지되는 현상 일부 고침.
  - 현재 애플로그인에서 시뮬 재시작을 하고 카카오 로그인을 진행할 경우에만 메인페이지 데이터가 애플로 덮어씌워짐. << 로그아웃시 해결은 됨.
 
- 애플과 카카오의 자동로그인을 구현하지 않았는데도 자동 로그인이 되는 현상 일부 고침
  - 애플은 자동로그인 막았고 애플에서 지원하는 공식 자동 로그인 구현 시도 중 
  - 카카오 계정으로의 자동 로그인은 지원안하는데 어떤 이유인지 자동로그인이 되어버림. << 이것이 위 문제와 연관있는듯

- 시뮬레이터 재시작시 프로필 페이지 가지지 않는 문제 해결

- 전체적인 폰트 수정