### PR TITLE
Feat/recording logic

### DIFF
--- a/lib/pages/user_profile_page/user_profile_page.dart
+++ b/lib/pages/user_profile_page/user_profile_page.dart
@@ -9,6 +9,7 @@ import 'package:nota_note/theme/pretendard_text_styles.dart';
 import 'package:nota_note/viewmodels/auth/auth_common.dart';
 import 'package:nota_note/pages/user_profile_page/widgets/profile_image_widget.dart';
 import 'package:nota_note/providers/user_profile_provider.dart';
+import 'package:nota_note/services/recording_local_storage_service.dart';
 
 /// 사용자 프로필 페이지
 class UserProfilePage extends ConsumerWidget {
@@ -378,6 +379,9 @@ class UserProfilePage extends ConsumerWidget {
       await firestore.collection('users').doc(userId).delete();
 
       // (필요시 기타 데이터도 삭제)
+      // 로컬 녹음 기록 모두 삭제
+      final storageService = RecordingLocalStorageService();
+      await storageService.deleteAllRecordings();
 
       // 로그아웃/정보 초기화
       await signOut();

--- a/lib/services/recording_local_storage_service.dart
+++ b/lib/services/recording_local_storage_service.dart
@@ -78,4 +78,15 @@ class RecordingLocalStorageService {
       whereArgs: [path],
     );
   }
+  Future<void> deleteAllRecordings() async {
+    final db = await database;
+    final recordings = await getAllRecordings();
+    for (var recording in recordings) {
+      final file = File(recording.path);
+      if (await file.exists()) {
+        await file.delete();
+      }
+    }
+    await db.delete('recordings');
+  }
 }


### PR DESCRIPTION
이제 사용자가 회원 탈퇴를 하면 해당 디바이스의 모든 녹음 기록이 지워집니다. 

네 맞습니다. 한 디바이스의 모든 기록이니까 다른 계정의 녹음기록도 포함입니다. 그럴 확률은 적으니 나중에 유저 id까지 데이터베이스에 함께 저장해서 취사 삭제를 하도록 시간이 남으면 로직을 바꿔보겠습니다.