### PR TITLE
Fix/font size

### DIFF
--- a/lib/pages/memo_page/widgets/color_picker_widget.dart
+++ b/lib/pages/memo_page/widgets/color_picker_widget.dart
@@ -4,16 +4,13 @@ import 'package:flutter_quill/flutter_quill.dart';
 class ColorPickerWidget extends StatelessWidget {
   final QuillController controller;
   final VoidCallback onClose;
+  final Function(Color) onColorSelected;
 
-  ColorPickerWidget({required this.controller, required this.onClose});
-
-  void _applyColor(Color color) {
-    final selection = controller.selection;
-    if (selection.isValid) {
-      controller.formatSelection(Attribute.fromKeyValue('color', '#${color.value.toRadixString(16).padLeft(8, '0').substring(2)}'));
-    }
-    // onClose() 호출 제거: 색상 선택 후 UI 유지
-  }
+  ColorPickerWidget({
+    required this.controller,
+    required this.onClose,
+    required this.onColorSelected,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -35,7 +32,7 @@ class ColorPickerWidget extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
             GestureDetector(
-              onTap: () => _applyColor(Color(0xFFDC2828)),
+              onTap: () => onColorSelected(Color(0xFFDC2828)),
               child: Container(
                 width: 24,
                 height: 24,
@@ -47,7 +44,7 @@ class ColorPickerWidget extends StatelessWidget {
             ),
             const SizedBox(width: 18),
             GestureDetector(
-              onTap: () => _applyColor(Color(0xFFDC7628)),
+              onTap: () => onColorSelected(Color(0xFFDC7628)),
               child: Container(
                 width: 24,
                 height: 24,
@@ -59,7 +56,7 @@ class ColorPickerWidget extends StatelessWidget {
             ),
             const SizedBox(width: 18),
             GestureDetector(
-              onTap: () => _applyColor(Color(0xFFDCB528)),
+              onTap: () => onColorSelected(Color(0xFFDCB528)),
               child: Container(
                 width: 24,
                 height: 24,
@@ -71,7 +68,7 @@ class ColorPickerWidget extends StatelessWidget {
             ),
             const SizedBox(width: 18),
             GestureDetector(
-              onTap: () => _applyColor(Color(0xFF2DA309)),
+              onTap: () => onColorSelected(Color(0xFF2DA309)),
               child: Container(
                 width: 24,
                 height: 24,
@@ -83,7 +80,7 @@ class ColorPickerWidget extends StatelessWidget {
             ),
             const SizedBox(width: 18),
             GestureDetector(
-              onTap: () => _applyColor(Color(0xFF1535EA)),
+              onTap: () => onColorSelected(Color(0xFF1535EA)),
               child: Container(
                 width: 24,
                 height: 24,
@@ -95,7 +92,7 @@ class ColorPickerWidget extends StatelessWidget {
             ),
             const SizedBox(width: 18),
             GestureDetector(
-              onTap: () => _applyColor(Color(0xFF000000)),
+              onTap: () => onColorSelected(Color(0xFF000000)),
               child: Container(
                 width: 24,
                 height: 24,

--- a/lib/pages/memo_page/widgets/highlight_picker_widget.dart
+++ b/lib/pages/memo_page/widgets/highlight_picker_widget.dart
@@ -5,19 +5,13 @@ import 'package:flutter_svg/flutter_svg.dart';
 class HighlightPickerWidget extends StatelessWidget {
   final QuillController controller;
   final VoidCallback onClose;
+  final Function(Color?) onHighlightSelected;
 
-  HighlightPickerWidget({required this.controller, required this.onClose});
-
-  void _applyHighlight(Color? color) {
-    final selection = controller.selection;
-    if (selection.isValid) {
-      if (color == null) {
-        controller.formatSelection(Attribute.clone(Attribute.background, null));
-      } else {
-        controller.formatSelection(Attribute.fromKeyValue('background', '#${color.value.toRadixString(16).padLeft(8, '0').substring(2)}'));
-      }
-    }
-  }
+  HighlightPickerWidget({
+    required this.controller,
+    required this.onClose,
+    required this.onHighlightSelected,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -39,7 +33,7 @@ class HighlightPickerWidget extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
             GestureDetector(
-              onTap: () => _applyHighlight(Color(0xFFF4C0C0)),
+              onTap: () => onHighlightSelected(Color(0xFFF4C0C0)),
               child: Container(
                 width: 24,
                 height: 24,
@@ -51,7 +45,7 @@ class HighlightPickerWidget extends StatelessWidget {
             ),
             const SizedBox(width: 18),
             GestureDetector(
-              onTap: () => _applyHighlight(Color(0xFFF3D3BA)),
+              onTap: () => onHighlightSelected(Color(0xFFF3D3BA)),
               child: Container(
                 width: 24,
                 height: 24,
@@ -63,7 +57,7 @@ class HighlightPickerWidget extends StatelessWidget {
             ),
             const SizedBox(width: 18),
             GestureDetector(
-              onTap: () => _applyHighlight(Color(0xFFEEDC9B)),
+              onTap: () => onHighlightSelected(Color(0xFFEEDC9B)),
               child: Container(
                 width: 24,
                 height: 24,
@@ -75,7 +69,7 @@ class HighlightPickerWidget extends StatelessWidget {
             ),
             const SizedBox(width: 18),
             GestureDetector(
-              onTap: () => _applyHighlight(Color(0xFFC7EBBC)),
+              onTap: () => onHighlightSelected(Color(0xFFC7EBBC)),
               child: Container(
                 width: 24,
                 height: 24,
@@ -87,7 +81,7 @@ class HighlightPickerWidget extends StatelessWidget {
             ),
             const SizedBox(width: 18),
             GestureDetector(
-              onTap: () => _applyHighlight(Color(0xFFCFE4F5)),
+              onTap: () => onHighlightSelected(Color(0xFFCFE4F5)),
               child: Container(
                 width: 24,
                 height: 24,
@@ -99,7 +93,7 @@ class HighlightPickerWidget extends StatelessWidget {
             ),
             const SizedBox(width: 18),
             GestureDetector(
-              onTap: () => _applyHighlight(null),
+              onTap: () => onHighlightSelected(null),
               child: SvgPicture.asset(
                 'assets/icons/HighlightCancel.svg',
                 width: 24,

--- a/lib/viewmodels/page_viewmodel.dart
+++ b/lib/viewmodels/page_viewmodel.dart
@@ -40,7 +40,6 @@ class PageViewModel extends StateNotifier<page_model.Page> {
               TextSelection.collapsed(offset: length),
               ChangeSource.local,
             );
-            print('Loaded Delta JSON: ${page.content}');
           } else {
             controller.document = Document();
           }
@@ -79,7 +78,6 @@ class PageViewModel extends StateNotifier<page_model.Page> {
       return;
     }
     final deltaJson = controller.document.toDelta().toJson();
-    print('Saving Delta JSON: $deltaJson');
     final page = state.copyWith(content: deltaJson);
 
     try {
@@ -92,7 +90,6 @@ class PageViewModel extends StateNotifier<page_model.Page> {
           .doc(pageId)
           .set(page.toFirestore());
       state = page;
-      print('Save successful for pageId: $pageId, content: ${page.content}');
     } catch (e, stackTrace) {
       print('Save failed: $e');
       print('Stack trace: $stackTrace');


### PR DESCRIPTION
텍스트 속성을 바꿀 때, 한글은 조합형 문자이기 때문에 영어처럼 정확하게 int 형태로 위치가 추적되지 않았습니다.

이 때문에 flutter_quill 패키지에서는 한글을 입력할 때, 내가 선택한 텍스트 포멧팅을 무시하고 이전의 속성으로 돌아가는 문제가 있었습니다.

이 문제는 텍스트 속성을 에디터 바에서 바꾸는 순간, \u200B라는 가짜 문자를 커서 위치와 커서의 뒤 양쪽에 배치함으로써, 그 "이전의 속성"을 내가 원하는 속성으로 변경함으로써 우회적으로 해결할 수 있었습니다.

