### PR TITLE
Feat/pdf export

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,5 +1,6 @@
 import Flutter
 import UIKit
+import KakaoSDKAuth
 
 @main
 @objc class AppDelegate: FlutterAppDelegate {
@@ -9,5 +10,13 @@ import UIKit
   ) -> Bool {
     GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+   // 카카오톡으로 로그인을 위한 설정
+  override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+      if (AuthApi.isKakaoTalkLoginUrl(url)) {
+          return AuthApi.handleOpenUrl(url: url)
+      }
+      // 다른 플러그인(구글, 파이어베이스 등등) 처리를 위해 super 유지
+      return super.application(app, open: url, options: options)
   }
 }

--- a/lib/viewmodels/auth/auth_common.dart
+++ b/lib/viewmodels/auth/auth_common.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 import 'dart:developer';
 import 'package:crypto/crypto.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
 import 'package:nota_note/pages/login_page/shared_prefs_helper.dart';

--- a/lib/viewmodels/auth/kakao_auth_viewmodel.dart
+++ b/lib/viewmodels/auth/kakao_auth_viewmodel.dart
@@ -8,7 +8,6 @@ import 'package:nota_note/viewmodels/auth/auth_common.dart';
 import 'package:nota_note/viewmodels/auth/user_id_provider.dart';
 import 'package:nota_note/services/note_group_exemple_service.dart';
 
-
 final kakaoAuthViewModelProvider =
     Provider<KakaoAuthViewModel>((ref) => KakaoAuthViewModel(ref));
 
@@ -17,23 +16,22 @@ class KakaoAuthViewModel {
   KakaoAuthViewModel(this.ref);
 
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
-  final NoteGroupExampleService _noteGroupExampleService = NoteGroupExampleService();
-
+  final NoteGroupExampleService _noteGroupExampleService =
+      NoteGroupExampleService();
 
   Future<UserModel?> signInWithKakao() async {
     try {
+      //카카오톡 설치 여부
       final isInstalled = await isKakaoTalkInstalled();
       final token = isInstalled
-          ? await UserApi.instance.loginWithKakaoTalk()
-          : await UserApi.instance.loginWithKakaoAccount();
+          ? await UserApi.instance.loginWithKakaoTalk() //카카오톡 앱 로그인
+          : await UserApi.instance.loginWithKakaoAccount(); //카카오계정 웹 로그인
 
       final user = await UserApi.instance.me();
       final userId = user.id.toString();
-
       final email = user.kakaoAccount?.email ?? 'no_email@kakao.com';
       final displayName = user.kakaoAccount?.profile?.nickname ?? 'Unknown';
       final photoUrl = user.kakaoAccount?.profile?.profileImageUrl ?? '';
-
       final docRef = _firestore.collection('users').doc(userId);
       final userDoc = await docRef.get();
 
@@ -50,7 +48,6 @@ class KakaoAuthViewModel {
         );
         await docRef.set(newUser.toJson(), SetOptions(merge: true));
         await _noteGroupExampleService.createExampleNoteGroup(userId);
-
       }
 
       await saveLoginUserId(userId);


### PR DESCRIPTION
- 카카오톡에서 서비스 앱으로 돌아왔을 때 카카오 로그인 처리를 정상적으로 완료하기 위해 AppDelegate.swift에 handleOpenUrl() 추가.