### PR TITLE
리뷰요청 점검 및 위치변경

### DIFF
--- a/lib/pages/main_page/main_page.dart
+++ b/lib/pages/main_page/main_page.dart
@@ -24,6 +24,8 @@ import 'package:nota_note/viewmodels/memo_viewmodel.dart';
 import 'package:nota_note/pages/memo_page/memo_page.dart';
 import 'package:nota_note/models/role.dart';
 import 'package:nota_note/models/shared_group_with_role.dart';
+import 'package:nota_note/utils/review_helper.dart';
+
 
 class MainPage extends ConsumerStatefulWidget {
   const MainPage({super.key});
@@ -49,6 +51,7 @@ class _MainPageState extends ConsumerState<MainPage>
   @override
   void initState() {
     super.initState();
+  ReviewHelper.checkAndRequestReview();
     _loadUserInfo();
     _searchController.addListener(_onSearchChanged);
     _fabAnimationController = AnimationController(

--- a/lib/utils/review_helper.dart
+++ b/lib/utils/review_helper.dart
@@ -1,6 +1,6 @@
-// lib/utils/review_helper.dart
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:in_app_review/in_app_review.dart';
+import 'package:flutter/foundation.dart'; // kDebugMode 사용
 
 class ReviewHelper {
   static const _launchCountKey = 'launch_count';
@@ -11,27 +11,29 @@ class ReviewHelper {
     final prefs = await SharedPreferences.getInstance();
 
     final hasRequestedReview = prefs.getBool(_hasRequestedReviewKey) ?? false;
+    int launchCount = prefs.getInt(_launchCountKey) ?? 0;
+
+    if (kDebugMode) {
+      debugPrint('✅ [리뷰체크] 실행 횟수: $launchCount / 리뷰 요청함?: $hasRequestedReview');
+    }
+
     if (hasRequestedReview) return;
 
-    int launchCount = prefs.getInt(_launchCountKey) ?? 0;
     launchCount++;
     await prefs.setInt(_launchCountKey, launchCount);
 
-    // 조건: 앱 3회 실행 시 리뷰 요청
     if (launchCount == 3) {
       final inAppReview = InAppReview.instance;
       if (await inAppReview.isAvailable()) {
+        if (kDebugMode) {
+          debugPrint('🎯 [리뷰체크] 조건 만족! 리뷰 요청 시도');
+        }
         await inAppReview.requestReview();
         await prefs.setBool(_hasRequestedReviewKey, true);
+        if (kDebugMode) {
+          debugPrint('🙌 [리뷰체크] 리뷰 요청 완료 및 플래그 저장');
+        }
       }
-    }
-  }
-
-  /// 수동 리뷰 요청 (리뷰 남기기 버튼 등에서 사용)
-  static Future<void> forceRequestReview() async {
-    final inAppReview = InAppReview.instance;
-    if (await inAppReview.isAvailable()) {
-      await inAppReview.requestReview();
     }
   }
 }


### PR DESCRIPTION
## 오늘 작업 내역

### 인앱 리뷰 기능 구현

- 앱 실행 횟수를 카운트하여 **3회 실행 시 인앱 리뷰 팝업 요청** 기능 추가
- 리뷰 팝업 호출 여부는 OS/스토어 정책에 따라 시스템이 자동 결정
- `ReviewHelper` 유틸 클래스 구현 및 SharedPreferences로 상태 저장
- 디버그 환경에서는 `debugPrint`로 실행 로그 확인 가능 (`kDebugMode` 활용)

### 호출 위치 변경 (`main.dart` → `main_page.dart`)

- 앱 전체 실행 직후가 아닌, **메인 페이지 진입 시점(MainPage)** 에 리뷰 체크하도록 위치 조정
- 이유: `SplashPage` 또는 로그인 흐름 이후 사용자 진입 시점에서만 리뷰 체크하도록 분리
- `MainPage`의 `initState()`에서 `ReviewHelper.checkAndRequestReview()` 호출

```dart
@override
void initState() {
  super.initState();
  ReviewHelper.checkAndRequestReview(); // ← 여기로 이동
  ...
}
